### PR TITLE
Create test for Header.js rendering

### DIFF
--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -11,9 +11,7 @@ it('renders without crashing', () => {
 });
 
 describe('<App />', () => {
-  const mockUpdateSearchQuery = jest.fn();
-  const mockGetMockArticles = jest.fn();
-
+  
   it('should render a <Header />', () => {
     const { getByTestId } = render(<App />);
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,47 +1,19 @@
 import React from 'react';
 import './Header.css';
+import SearchForm from '../SearchForm/SearchForm';
 
-class Header extends React.Component {
-  constructor(props) {
-    super();
-
-    this.state = {
-      searchQuery: ''
-    }
-  }
-
-  updateSearchQuery = (e) => {
-    this.setState({searchQuery: e.target.value.toLowerCase()})
-  }
-
-  searchArticles = (e) => {
-    e.preventDefault();
-    this.props.updateSearchQuery(this.state.searchQuery);
-    this.setState({searchQuery: ''})
-  }
-
-  render() {
-    return (
-      <header className='header' data-testid='header'>
-        <h1>What's
-          <span>News?</span>
-        </h1>
-        <form className='search-bar' data-testid='search-bar'>
-          <input
-            value={this.state.searchQuery}
-            type='search'
-            placeholder='Search for article'
-            onChange={this.updateSearchQuery}
-          />
-          <button
-            onClick={this.searchArticles}
-          >
-            Search
-          </button>
-        </form>
-      </header>
-    )
-  }
+const Header = (props) => {
+  return (
+    <header className='header' data-testid='header'>
+      <h1>What's
+        <span>News?</span>
+      </h1>
+      <SearchForm
+        searchQuery={props.searchQuery}
+        updateSearchQuery={props.updateSearchQuery}
+      />
+    </header>
+  )
 }
 
 export default Header;

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,1 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Header from './Header';
+import {fireEvent, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 
+describe('<Header />', () => {
+  it('Should display a logo and a search component', () => {
+    const { getByPlaceholderText, getByText } = render(<Header />);
+
+    expect(getByText(/What's/i)).toBeInTheDocument();
+    expect(getByText(/Search/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -1,6 +1,43 @@
 import React from 'react';
 import './SearchForm.css';
 
-// SEARCHFORM COMPONENT CODE GOES HERE
+class SearchForm extends React.Component {
+  constructor(props) {
+    super();
+
+    this.state = {
+      searchQuery: ''
+    }
+  }
+
+  updateSearchQuery = (e) => {
+    this.setState({searchQuery: e.target.value.toLowerCase()})
+  }
+
+  searchArticles = (e) => {
+    e.preventDefault();
+    this.props.updateSearchQuery(this.state.searchQuery);
+    this.setState({searchQuery: ''})
+  }
+
+  render() {
+    return (
+        <form className='search-bar' data-testid='search-bar'>
+          <input
+            value={this.state.searchQuery}
+            type='search'
+            placeholder='Search for article'
+            onChange={this.updateSearchQuery}
+          />
+          <button
+            onClick={this.searchArticles}
+          >
+            Search
+          </button>
+        </form>
+    )
+  }
+}
+
 
 export default SearchForm;


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features
- [x] Test

### Detailed Description
First and foremost I moved the logic for the search bar into the different component of SearchForm.js. Essentially these two separate component do the exact same thing as when the form lived in the Header.js but now when I render the header it is passing the updateSearchQuery function and the searchQuery state from the App down into the SearchForm as props. 

I also, wrote out the test for the header to show case the logo and search component are rendering as I expect them to. 
### Why is this change required? What problem does it solve?

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

### Files modified:
- [ ] index.html
- [ ] App.js
- [ ] NewsContainer.js
- [ ] NewsArticle.js
- [x] SearchForm.js
- [x] Header.js
- [ ] Menu.js
- [ ] App-test.js
- [ ] NewsContainer-test.js
- [ ] NewsArticle-test.js
- [ ] SearchForm-test.js
- [ ] Menu-test.js 
- [x] Header.test.js
- [ ] Other files:
