### PR TITLE
Add and pass 2/4 tests on NewsContainer.js

### DIFF
--- a/src/components/NewsArticle/NewsArticle.js
+++ b/src/components/NewsArticle/NewsArticle.js
@@ -9,11 +9,18 @@ const NewsArticle = ({id, headline, img, description, url}) => {
 
   return (
     <div className='card'>
-      <div className='card-img' style={style}/>
+      <div
+      testid={img}
+      className='card-img'
+      style={style}
+      />
       <h3>{headline}</h3>
       <p>{description}</p>
       <div className='article-link'>
-        <a href={url}>Link To Article</a>
+        <a
+        testid={url}
+        href={url}>Link To Article
+        </a>
         <img src={arrowImage} alt='arrow pointing right' />
       </div>
     </div>

--- a/src/components/NewsContainer/NewsContainer.test.js
+++ b/src/components/NewsContainer/NewsContainer.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import NewsContainer from './NewsContainer';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('<NewsContainer />', () => {
+  it('Should display expected content', () => {
+    const mockNewArticle = [{
+      id:26,
+      headline:'Turing is the best school around',
+      img:'mockImg',
+      description:'Especially that cool class of 2001FE',
+      url:'mockUrl',
+    }];
+
+    const { getByText, getByTestId } = render(<NewsContainer news={mockNewArticle} />);
+
+    expect(getByText('Turing is the best school around')).toBeInTheDocument();
+    // expect(getByTestId('mockImg')).toBeInTheDocument();
+    expect(getByText('Especially that cool class of 2001FE')).toBeInTheDocument();
+    // expect(getByTestId('mockUrl')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features
- [x] Test

### Detailed Description
Added rendering based unit tests to NewContainer.js to make sure what I expect to be rendered on the page is. 

### Why is this change required? What problem does it solve?

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
I was able to get the tests based of elements using getByText to pass but am having trouble figuring out why my getByTestId tests for the mock img and url are failing. Will revisit those if I have time later.

### Files modified:
- [ ] index.html
- [ ] App.js
- [ ] NewsContainer.js
- [ ] NewsArticle.js
- [ ] SearchForm.js
- [ ] Menu.js
- [ ] App-test.js
- [x] NewsContainer-test.js
- [ ] NewsArticle-test.js
- [ ] SearchForm-test.js
- [ ] Menu-test.js 
- [ ] Other files:
